### PR TITLE
[fix](trac #323129): Made number of capture channels changable according to current input Audio device.

### DIFF
--- a/LFLiveKit/LFLiveSession.h
+++ b/LFLiveKit/LFLiveSession.h
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, LFLiveCaptureTypeMask)
 @end
 
 @protocol LFLiveSessionRecordingDelegate <NSObject>
-- (void)liveSession:(nullable LFLiveSession *)session didReceiveAudioData:(nonnull NSData *)data;
+- (void)liveSession:(nullable LFLiveSession *)session didReceiveAudioData:(nonnull NSData *)data withNumberOfChannels:(nonnull NSUInteger)numberOfChannels;
 @end
 
 @class LFLiveStreamInfo;

--- a/LFLiveKit/LFLiveSession.h
+++ b/LFLiveKit/LFLiveSession.h
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, LFLiveCaptureTypeMask)
 @end
 
 @protocol LFLiveSessionRecordingDelegate <NSObject>
-- (void)liveSession:(nullable LFLiveSession *)session didReceiveAudioData:(nonnull NSData *)data withNumberOfChannels:(nonnull NSUInteger)numberOfChannels;
+- (void)liveSession:(nullable LFLiveSession *)session didReceiveAudioData:(nonnull NSData *)data withNumberOfChannels:(NSUInteger)numberOfChannels;
 @end
 
 @class LFLiveStreamInfo;

--- a/LFLiveKit/LFLiveSession.m
+++ b/LFLiveKit/LFLiveSession.m
@@ -165,8 +165,8 @@
 {
 	_audioDevice = audioDevice;
 	Float64 sampleRate = 44100;
-	[self.audioCaptureSource setAudioCaptureDevice:_audioDevice sampleRate:&sampleRate];
-	self.audioConfiguration.audioSampleRate = sampleRate;
+	UInt32 channels = 2;
+	[self.audioCaptureSource setAudioCaptureDevice:_audioDevice sampleRate:&sampleRate channels:&channels];	self.audioConfiguration.audioSampleRate = sampleRate;
 	_audioEncoder = nil;
 	[self audioEncoder];
 }
@@ -196,7 +196,7 @@
 		[self.audioEncoder encodeAudioData:audioData timeStamp:NOW];
 	}
 	if (self.recordingDelegate) {
-		[self.recordingDelegate liveSession:self didReceiveAudioData:audioData];
+		[self.recordingDelegate liveSession:self didReceiveAudioData:audioData withNumberOfChannels:_audioConfiguration.numberOfChannels];
 	}
 }
 
@@ -376,9 +376,11 @@
 	if (!_audioCaptureSource) {
 		if (self.captureType & LFLiveCaptureMaskAudio) {
 			Float64 sampleRate = 44100;
-			_audioCaptureSource = [[LFAudioCapture alloc] initWithAudioConfiguration:_audioConfiguration audioCaptureDevice:_audioDevice sampleRate:&sampleRate];
+			UInt32 channels = 2;
+			_audioCaptureSource = [[LFAudioCapture alloc] initWithAudioConfiguration:_audioConfiguration audioCaptureDevice:_audioDevice sampleRate:&sampleRate channels:&channels];
 			_audioCaptureSource.delegate = self;
 			self.audioConfiguration.audioSampleRate = sampleRate;
+			self.audioConfiguration.numberOfChannels = channels;
 			self.audioEncoder = nil;
 		}
 	}

--- a/LFLiveKit/LFLiveSession.m
+++ b/LFLiveKit/LFLiveSession.m
@@ -166,7 +166,9 @@
 	_audioDevice = audioDevice;
 	Float64 sampleRate = 44100;
 	UInt32 channels = 2;
-	[self.audioCaptureSource setAudioCaptureDevice:_audioDevice sampleRate:&sampleRate channels:&channels];	self.audioConfiguration.audioSampleRate = sampleRate;
+	[self.audioCaptureSource setAudioCaptureDevice:_audioDevice sampleRate:&sampleRate channels:&channels];
+	self.audioConfiguration.audioSampleRate = sampleRate;
+	self.audioConfiguration.numberOfChannels = channels;
 	_audioEncoder = nil;
 	[self audioEncoder];
 }

--- a/LFLiveKit/capture/LFAudioCapture.h
+++ b/LFLiveKit/capture/LFAudioCapture.h
@@ -43,8 +43,8 @@ extern NSString *_Nullable const LFAudioComponentFailedToCreateNotification;
 - (nullable instancetype)init UNAVAILABLE_ATTRIBUTE;
 + (nullable instancetype)new UNAVAILABLE_ATTRIBUTE;
 
-- (nullable instancetype)initWithAudioConfiguration:(nullable LFLiveAudioConfiguration *)configuration audioCaptureDevice:(nullable AVCaptureDevice *)device sampleRate:(nonnull Float64 *)outSampleRate NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithAudioConfiguration:(nullable LFLiveAudioConfiguration *)configuration audioCaptureDevice:(nullable AVCaptureDevice *)device sampleRate:(Float64 *)outSampleRate channels:(UInt32 *)outChannels NS_DESIGNATED_INITIALIZER;
 
-- (void)setAudioCaptureDevice:(nonnull AVCaptureDevice *)device sampleRate:(nonnull Float64 *)outSampleRate;
+- (void)setAudioCaptureDevice:(nonnull AVCaptureDevice *)device sampleRate:(Float64 *)outSampleRate channels:(UInt32 *)outChannels;
 
 @end

--- a/LFLiveKit/capture/LFAudioCapture.m
+++ b/LFLiveKit/capture/LFAudioCapture.m
@@ -158,6 +158,10 @@ NSString *const LFAudioComponentFailedToCreateNotification = @"LFAudioComponentF
 		return;
 	}
 	AVCaptureDevice *captureDevice = [AVCaptureDevice deviceWithUniqueID: (__bridge NSString *)uidString];
+	if (!captureDevice) {
+		NSLog(@"No available captureDevice with uid: %@", uidString);
+		return;
+	}
 	UInt32 channels = 0;
 	Float64 sampleRate = 0;
 	for (NSUInteger i = 0; i < [captureDevice formats].count; i++) {

--- a/LFLiveKit/capture/LFAudioCapture.m
+++ b/LFLiveKit/capture/LFAudioCapture.m
@@ -175,6 +175,11 @@ NSString *const LFAudioComponentFailedToCreateNotification = @"LFAudioComponentF
 			}
 			
 		}
+		propertyAddress.mSelector = kAudioDevicePropertyNominalSampleRate;
+		status = AudioObjectSetPropertyData(device, &propertyAddress, 0, NULL, sizeof(newSampleRate), &newSampleRate);
+		if (noErr != status) {
+			return;
+		}
 		*outSampleRate = newSampleRate;
 		*outChannels = newChannels;
 	}


### PR DESCRIPTION
**Fixed Issue
When using device with one channel input, streaming outputs two channels but one of them is mute.

**Solution
Made number of capture channels changeable according to current input Audio device.